### PR TITLE
prepare for new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-6to5",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/gordonkristan/ember-cli-6to5",
   "dependencies": {
-    "broccoli-6to5-transpiler": "^0.1.1",
+    "broccoli-6to5-transpiler": "^2.0.0",
     "broccoli-filter": "^0.1.10"
   }
 }


### PR DESCRIPTION
- update the broccoli-6to5-transpiler (which now uses 6to5-core which doesn't bring along all the native extensions specific to the 6to5 lib)
- bump version