### PR TITLE
Fix 6to5 URL on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in your project and run it through the 6to5 transpiler to convert the ES6 code t
 through the transpiler shouldn't change the code at all (likely just a format change if it does).
 
 If you need to customize the way that 6to5 transfoms your code, you can do it by passing in any of the options
-found [here](https://6to5.org/usage.html#options). Example:
+found [here](https://6to5.org/docs/usage/options/). Example:
 
 ```js
 // Brocfile.js
@@ -36,4 +36,3 @@ this plugin disables 6to5 module compilation by blacklisting that transform. If 
 the 6to5 module transform instead of the Ember-CLI one, you'll have to explicitly set `compileModules` to `true`
 in your configuration. If `compileModules` is anything other than `true`, this plugin will leave the module
 syntax compilation up to Ember-CLI.
-


### PR DESCRIPTION
The 6to5 site was recently updated. This causes an old URL on the README.md (https://6to5.org/usage.html#options) to be redirected to http://6to5.org/docs/usage/cli/ .
The new URL is http://6to5.org/docs/usage/options/