### PR TITLE
Bump 6to5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/gordonkristan/ember-cli-6to5",
   "dependencies": {
-    "broccoli-6to5-transpiler": "^2.0.1",
+    "broccoli-6to5-transpiler": "^2.0.4",
     "broccoli-filter": "^0.1.10"
   }
 }


### PR DESCRIPTION
This version fixes a problem with 6to5 & emberscript working together.

related: https://github.com/ember-cli/ember-cli/issues/2999